### PR TITLE
Allow specifying a table name for has_many through

### DIFF
--- a/lib/is_paranoid.rb
+++ b/lib/is_paranoid.rb
@@ -55,7 +55,8 @@ module IsParanoid
     # NOTE: this only works if is_paranoid is declared before has_many relationships.
     def has_many(association_id, options = {}, &extension)
        if options.key?(:through)
-        paranoid_conditions = "#{options[:through].to_s.pluralize}.#{destroyed_field} #{is_or_equals_not_destroyed}"
+        through_table = options.delete(:through_table) || options[:through]
+        paranoid_conditions = "#{through_table.to_s.pluralize}.#{destroyed_field} #{is_or_equals_not_destroyed}"
         full_conditions = "(" + [options[:conditions], paranoid_conditions].compact.join(") AND (") + ")"
         options[:conditions] = "\#{IsParanoid.disabled? ? #{options.fetch(:conditions, '1=1').inspect} : #{full_conditions.inspect}}"
       end


### PR DESCRIPTION
Without this relations named something other than their table name can't be used as the `through` argument to `has_many`.

An alternative fix would be to reflect on the relation and get its table name, but that creates some weird order dependencies that this more explicit approach avoids.
