### PR TITLE
Rails 3: Fix a bug with handling conditions on a has_many through

### DIFF
--- a/lib/is_paranoid.rb
+++ b/lib/is_paranoid.rb
@@ -59,9 +59,10 @@ module IsParanoid
     # NOTE: this only works if is_paranoid is declared before has_many relationships.
     def has_many(association_id, options = {}, &extension)
        if options.key?(:through)
+        original_conditions = options.fetch(:conditions, '1=1')
         paranoid_conditions = "#{options[:through].to_s.pluralize}.#{destroyed_field} #{is_or_equals_not_destroyed}"
         full_conditions = "(" + [options[:conditions], paranoid_conditions].compact.join(") AND (") + ")"
-        options[:conditions] = proc { IsParanoid.disabled? ? options.fetch(:conditions, '1=1') : full_conditions }
+        options[:conditions] = proc { IsParanoid.disabled? ? original_conditions : full_conditions }
       end
       super
     end

--- a/spec/is_paranoid_spec.rb
+++ b/spec/is_paranoid_spec.rb
@@ -105,6 +105,24 @@ describe IsParanoid do
         end
       end
 
+      it 'works with has_many through with conditions' do
+        dent = @r2d2.dents.create!
+        ding_a = dent.dings.create!
+        ding_b = dent.dings.create!
+
+        @r2d2.dings.order('id asc').should == [ding_a, ding_b]
+        IsParanoid.disable {  @r2d2.dings.order('id asc').should == [ding_a, ding_b] }
+
+        ding_b.update_attributes!(hidden: true)
+        @r2d2.dings.order('id asc').should == [ding_a]
+        IsParanoid.disable { @r2d2.dings.reload.should == [ding_a] }
+
+        ding_b.update_attributes!(hidden: false)
+        ding_b.destroy
+        @r2d2.dings.order('id asc').should == [ding_a]
+        IsParanoid.disable { @r2d2.dings.reload.should == [ding_a, ding_b] }
+      end
+
       it "should not choke has_and_belongs_to_many relationships" do
         @r2d2.places.should include(@tatooine)
         @tatooine.destroy

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -10,7 +10,7 @@ class Android < ActiveRecord::Base #:nodoc:
   has_one :sticker
   has_many :memories, :foreign_key => 'parent_id'
   has_many :dents
-  has_many :dings, :through => :dents
+  has_many :dings, :through => :dents, conditions: "dings.hidden = 'f'"
   has_many :scratches, :through => :dents
   has_and_belongs_to_many :places
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema.define(:version => 20090317164830) do
     t.integer  "dent_id"
     t.string   "description"
     t.boolean  "not_deleted"
+    t.boolean  "hidden", default: false
   end
 
   create_table "scratches", :force => true do |t|


### PR DESCRIPTION
# What does this PR do?

This changeset fixes a bug where the original conditions were not be passed through on a has_many through association. Instead if was circularly referencing itself which caused Arel to blow up.

Test added.