### PR TITLE
Rails 3: Add Rails 2 support for for interpolating deferred/dynamic conditions

### DIFF
--- a/spec/is_paranoid_spec.rb
+++ b/spec/is_paranoid_spec.rb
@@ -105,21 +105,37 @@ describe IsParanoid do
         end
       end
 
+      it 'works with has_many with conditions' do
+        dent = @r2d2.dents.create!
+
+        @r2d2.dents.should == [dent]
+        IsParanoid.disable { @r2d2.dents.should == [dent] }
+
+        dent.update_attributes!(hidden: true)
+        @r2d2.dents.reload.should == []
+        IsParanoid.disable { @r2d2.dents.reload.should == [] }
+
+        dent.update_attributes!(hidden: false)
+        dent.destroy
+        @r2d2.dents.should == []
+        IsParanoid.disable { @r2d2.dents.reload.should == [dent] }
+      end
+
       it 'works with has_many through with conditions' do
         dent = @r2d2.dents.create!
         ding_a = dent.dings.create!
         ding_b = dent.dings.create!
 
         @r2d2.dings.order('id asc').should == [ding_a, ding_b]
-        IsParanoid.disable {  @r2d2.dings.order('id asc').should == [ding_a, ding_b] }
+        IsParanoid.disable { @r2d2.dings.order('id asc').should == [ding_a, ding_b] }
 
         ding_b.update_attributes!(hidden: true)
-        @r2d2.dings.order('id asc').should == [ding_a]
+        @r2d2.dings.reload.order('id asc').should == [ding_a]
         IsParanoid.disable { @r2d2.dings.reload.should == [ding_a] }
 
         ding_b.update_attributes!(hidden: false)
         ding_b.destroy
-        @r2d2.dings.order('id asc').should == [ding_a]
+        @r2d2.dings.reload.order('id asc').should == [ding_a]
         IsParanoid.disable { @r2d2.dings.reload.should == [ding_a, ding_b] }
       end
 

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -9,8 +9,8 @@ class Android < ActiveRecord::Base #:nodoc:
   has_many :components, :dependent => :destroy
   has_one :sticker
   has_many :memories, :foreign_key => 'parent_id'
-  has_many :dents
-  has_many :dings, :through => :dents, conditions: "dings.hidden = 'f'"
+  has_many :dents, conditions: 'dents.hidden = #{include_hidden_condition}'
+  has_many :dings, :through => :dents, conditions: 'dings.hidden = #{include_hidden_condition}'
   has_many :scratches, :through => :dents
   has_and_belongs_to_many :places
 
@@ -19,6 +19,10 @@ class Android < ActiveRecord::Base #:nodoc:
   before_update :raise_hell
   def raise_hell
     raise "hell"
+  end
+
+  def include_hidden_condition
+    "'f'"
   end
 end
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -11,6 +11,7 @@ ActiveRecord::Schema.define(:version => 20090317164830) do
     t.integer  "android_id"
     t.string   "description"
     t.datetime "deleted_at"
+    t.boolean  "hidden", default: false
   end
 
   create_table "dings", :force => true do |t|


### PR DESCRIPTION
# What does this PR do?

This PR adds support for passing Rails-2-style dynamic conditions to help with transitioning to Rails 3.

E.g.

```ruby
has_many :dents, :dents, conditions: 'some_field = #{dynamic_value}'
has_many :dings, through: :dents, conditions: 'some_field = #{dynamic_value}'
```